### PR TITLE
Removed typed-ast from requirements (deprecated)

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -41,7 +41,6 @@ soupsieve==2.5
 sqlparse==0.4.4
 tomli==2.0.1
 tqdm==4.66.1
-typed-ast==1.4.3
 types-pytz==2023.3.1.1
 types-PyYAML==6.0.12.12
 typing_extensions==4.8.0


### PR DESCRIPTION
typed-ast is deprecated and we should use ast (included with Python 3), https://github.com/python/typed_ast/issues/179.

This fixes some installation problems on windows for me as well.
