### PR TITLE
added file input validation in for transformer page

### DIFF
--- a/app/capstone/transformer/views.py
+++ b/app/capstone/transformer/views.py
@@ -166,6 +166,9 @@ def transform(request: HttpRequest) -> HttpResponse:
                         ".pptx",
                         ".pdf",
                         ".txt",
+                        ".rtf",
+                        ".odt",
+                        ".odp",
                     ]
                     for uploaded_file in request.FILES.getlist("input_files"):
                         # Extract file extension and check if it's a valid extension
@@ -185,7 +188,7 @@ def transform(request: HttpRequest) -> HttpResponse:
                             # Invalid extension, return an error message
                             messages.error(
                                 request,
-                                "Invalid file type. Please upload only MS Word, MS PowerPoint, .pdf, or .txt files.",
+                                "Invalid file type. Please upload either MS Word, MS PowerPoint, OpenDocument, RTF, PDF, or TXT files.",
                             )
                             return render(
                                 request, "transform.html", {"form": TransformerForm()}


### PR DESCRIPTION
Input file field only accepts MS Word, MS PowerPoint, .pdf, or .txt files for transformations. Will result in an error message if an invalid file type is uploaded. 

If there are any other file types it should accept please let me know. I just went with what is most commonly used so the error message wouldn't be too word-y.