### PR TITLE
Subscription friction

### DIFF
--- a/app/capstone/transformer/subscriptionManager.py
+++ b/app/capstone/transformer/subscriptionManager.py
@@ -32,7 +32,7 @@ def give_subscription_to_user(
         subscription.save()
     else:
         old_end = subscription.end_date
-        subscription.end_date = old_end + timedelta(days=product.length_days)
+        subscription.end_date = old_end + timedelta(days=product.length_days) # type: ignore
         subscription.save()
 
 

--- a/app/capstone/transformer/views.py
+++ b/app/capstone/transformer/views.py
@@ -516,7 +516,7 @@ def profile(request: HttpRequest) -> HttpResponse:
                 )
         elif "delete" in request.POST:
             subscription_form = SubscriptionDeletionForm(request.POST)
-            if subscription_form.is_valid() and subscription_form.cleaned_data.get("delete"):  # type: ignore
+            if subscription_form.is_valid() and subscription_form.cleaned_data.get("delete"):
                 user = User.objects.get(id=request.user.id)  # type: ignore
                 delete_subscription(user)
                 messages.success(request, f"Your subscription has been deleted.")


### PR DESCRIPTION
Closes #232 

Changes:
Can extend a subscription of the same type without having to cancel it first. This is not allowed for subscriptions of different types (e.g. non-premium user with active subscription cannot buy a premium subscription).
Fixed a bug where users could not delete subcriptions that were no longer active.

Note:
I was unable to change the model drop down on the create page (so that only premium users can see GPT-4). Tried editting/creating django forms and using javascript to gray out unused options. Both methods resulted in errors I could not fix. Unfortunately, I don't have any more time to try and fix this so it won't be added. 